### PR TITLE
adjusted sources for Laravel 5.5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "illuminate/mail": "~5",
+        "illuminate/mail": "5.5.*",
         "mailin-api/mailin-api-php": "1.0.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,12 @@
 {
-    "name": "webup/laravel-sendinblue",
+    "name": "kaishiyoku/laravel-sendinblue",
     "description": "Laravel's mail transport for SendinBlue",
     "keywords": ["laravel", "laravel5", "lumen", "sendinblue", "stmp", "mailing"],
     "license": "MIT",
     "authors": [
         {
-            "name": "Baptiste Ducatel",
-            "email": "baptiste@agence-webup.com",
-            "homepage": "http://agence-webup.com",
-            "role": "Developer"
+            "name": "Kaishiyoku",
+            "email": "dev@andreas-wiedel.de"
         }
     ],
     "require": {

--- a/src/SendinBlueTransport.php
+++ b/src/SendinBlueTransport.php
@@ -31,7 +31,7 @@ class SendinBlueTransport extends Transport
     /**
      * {@inheritdoc}
      */
-    public function send(Swift_Mime_Message $message, &$failedRecipients = null)
+    public function send(\Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
     {
         $this->beforeSendPerformed($message);
 

--- a/tests/SendinBlueTransportTest.php
+++ b/tests/SendinBlueTransportTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Webup\LaravelSendinBlue\SendinBlueTransport;
 
-class SendinBlueTransportTest extends PHPUnit_Framework_TestCase
+class SendinBlueTransportTest extends TestCase
 {
     public function testSend()
     {


### PR DESCRIPTION
Please note: Due to change in `public function send(\Swift_Mime_SimpleMessage $message, &$failedRecipients = null)` it may be that this change is only compatible with Laravel 5.5.*