### PR TITLE
Support Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "illuminate/mail": "5.5.*",
+        "illuminate/mail": "5.5.*|5.6.*",
         "mailin-api/mailin-api-php": "1.0.2"
     },
     "require-dev": {


### PR DESCRIPTION
Idealy you could require "illuminate/contracts" instead of "illuminate/mail" if this a Laravel-only package...