### PR TITLE
Add custom headers to data array

### DIFF
--- a/src/SendinBlueTransport.php
+++ b/src/SendinBlueTransport.php
@@ -61,6 +61,16 @@ class SendinBlueTransport extends Transport
     {
         $data = [];
 
+        if ($message->getHeaders()) {
+            $headers = $message->getHeaders()->getAll();
+
+            foreach( $headers as $header) {
+                if( $header instanceof Swift_Mime_Headers_UnstructuredHeader ) {
+                    $data['headers'][$header->getFieldName()] = $header->getValue();
+                }
+            }
+        }
+
         if ($message->getTo()) {
             $data['to'] = $message->getTo();
         }

--- a/src/SendinBlueTransport.php
+++ b/src/SendinBlueTransport.php
@@ -7,6 +7,7 @@ use Sendinblue\Mailin;
 use Swift_Attachment;
 use Swift_Mime_SimpleMessage;
 use Swift_MimePart;
+use Swift_Mime_Headers_UnstructuredHeader;
 
 class SendinBlueTransport extends Transport
 {

--- a/tests/SendinBlueTransportTest.php
+++ b/tests/SendinBlueTransportTest.php
@@ -16,8 +16,12 @@ class SendinBlueTransportTest extends TestCase
             'subject' => 'My subject',
             'text' => 'This is the text',
             'html' => 'This is the <h1>HTML</h1>',
+            'headers' => [
+                'Content-Type' => 'multipart/alternative',
+                'MIME-Version' => '1.0',
+                'Subject' => 'My subject',
+            ],
             // 'attachment' => $attachment,
-            // 'headers' => []
             // 'inline_image' => []
         ];
 


### PR DESCRIPTION
Custom headers were not being included into the data array. That means it was impossible to use Laravel's built-in `withSwiftMessage()` function.
What I did was just looping through the headers array and pushing all instances of `Swift_Mime_Headers_UnstructuredHeader` to the data array before sending it to Sendinblue.