### PR TITLE
Drop all replyTo email addresses except last one

### DIFF
--- a/src/SendinBlueTransport.php
+++ b/src/SendinBlueTransport.php
@@ -140,7 +140,7 @@ class SendinBlueTransport extends Transport
                     'name' => $name,
                 ]);
             }
-            $smtpEmail->setReplyTo($replyTo);
+            $smtpEmail->setReplyTo(end($replyTo));
         }
 
         $attachment = [];


### PR DESCRIPTION
Setting replyTo in a Mailable object always results in a bad http call to the sendinblue api.

```php
class MyEmail extends Mailable
{
   ...
    public function build()
    {
        return $this
            ->replyTo("john@example.com", "John")
            ->markdown('emails.myEmail');
    }
}
```
> Client error: `POST https://api.sendinblue.com/v3/smtp/email` resulted in a `400 Bad Request` response: {"code":"invalid_parameter","message":"replyTo is not valid"} 

The formatted request is:

```json
{
  "replyTo":  [
    {
      "email": "john@example.com",
      "name": "John",
    }
  ]
}
```
SendInBlue doesn't seem to support multiple replyTo addresses.

You can see [in the docs](https://developers.sendinblue.com/reference#sendtransacemail) that it takes an object instead of an array of object.

I have provided this very little fix in the SendInBlueTransport class that keeps only the last replyTo address that have been set.

