### PR TITLE
Actual Laravel 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "illuminate/mail": "^5.5|^6.0|^7.0",
+        "illuminate/mail": "^7.0",
         "guzzlehttp/guzzle": "^6.3",
         "sendinblue/api-v3-sdk": "^6.1"
     },

--- a/src/SendinBlueServiceProvider.php
+++ b/src/SendinBlueServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Webup\LaravelSendinBlue;
 
 use Illuminate\Mail\MailManager;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 use SendinBlue\Client\Api\SMTPApi;
 use SendinBlue\Client\Configuration;

--- a/src/SendinBlueServiceProvider.php
+++ b/src/SendinBlueServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Webup\LaravelSendinBlue;
 
+use Illuminate\Mail\MailManager;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 use SendinBlue\Client\Api\SMTPApi;
 use SendinBlue\Client\Configuration;
@@ -16,8 +18,8 @@ class SendinBlueServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app['swift.transport']->extend('sendinblue', function ($app) {
-            return new SendinBlueTransport($app[SMTPApi::class]);
+        $this->app[MailManager::class]->extend('sendinblue', function ($app) {
+            return new SendinBlueTransport($this->app->make(SMTPApi::class));
         });
     }
 
@@ -30,7 +32,6 @@ class SendinBlueServiceProvider extends ServiceProvider
     {
         $this->app->singleton(SMTPApi::class, function ($app) {
             $config = Configuration::getDefaultConfiguration()->setApiKey($app['config']['services.sendinblue.key_identifier'], $app['config']['services.sendinblue.key']);
-            // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api-key', 'Bearer');
 
             return new SMTPApi(
                 new GuzzleClient,


### PR DESCRIPTION
After a few tests there's a problem with the [TransportManager](https://laravel.com/api/6.x/Illuminate/Mail/TransportManager.html ) which is initialized in the boot function but that doesn't exist anymore. It seems to have been replaced with the [MailManager](https://laravel.com/api/7.x/Illuminate/Mail/MailManager.html). This new version has been tested and works, and will probably need a 3.0 tag since it's a breaking change for all versions < laravel 7