### PR TITLE
allow logging of SendInBlue params when MAIL_DRIVER=log

### DIFF
--- a/src/SendinBlue.php
+++ b/src/SendinBlue.php
@@ -13,7 +13,7 @@ trait SendinBlue
      */
     public function sendinblue($extraFields)
     {
-        if ($this instanceof Mailable && $this->mailDriver() == "sendinblue") {
+        if ($this instanceof Mailable && ($this->mailDriver() == "sendinblue" || $this->mailDriver() == "log")) {
             $this->withSwiftMessage(
                 function (Swift_Message $message) use ($extraFields) {
                     $message->embed(


### PR DESCRIPTION
This pull request allows the SendInBlue headers to be included in the logged output when `MAIL_DRIVER=log` (Closes #53)


### Before (laravel.log)
```
[2022-02-03 16:58:41] local.DEBUG: Message-ID: <12f7a82ea538b80a817e4394f8dc07a8@swift.generated>
Date: Thu, 03 Feb 2022 16:58:41 +0000
Subject: ___TEMPLATE_SUBJECT___
From: [from]
To: [from]
MIME-Version: 1.0
Content-Type: text/plain; charset=utf-8
Content-Transfer-Encoding: quoted-printable
```

### After (laravel.log)
```
[2022-02-03 16:58:06] local.DEBUG: Message-ID: <961429f12f0b7692594f2e5fed174854@swift.generated>
Date: Thu, 03 Feb 2022 16:58:06 +0000
Subject: ___TEMPLATE_SUBJECT___
From: [from]
To: [from]
MIME-Version: 1.0
Content-Type: multipart/related;
 boundary="_=_swift_1643907486_5d22b16f62f22f44d0e6427961ba605e_=_"

Content-Type: application/octet-stream; name="sendinblue/x-extra-fields"
Content-Transfer-Encoding: base64
Content-ID: <39f679d58230b2843b1b0f3b5d6a65e0@swift.generated>
Content-Disposition: inline; filename="sendinblue/x-extra-fields"

{"template_id":2,"tags":[],"params":{"foo":"Bar"}}
```