### PR TITLE
(v2) - allow logging of SendInBlue params when MAIL_DRIVER=log #54

### DIFF
--- a/src/SendinBlue.php
+++ b/src/SendinBlue.php
@@ -13,7 +13,7 @@ trait SendinBlue
      */
     public function sendinblue($extraFields)
     {
-        if ($this instanceof Mailable && $this->mailDriver() == "sendinblue") {
+        if ($this instanceof Mailable && ($this->mailDriver() == "sendinblue" || $this->mailDriver() == "log")) {
             $this->withSwiftMessage(
                 function (Swift_Message $message) use ($extraFields) {
                     $message->embed(


### PR DESCRIPTION
This PR makes the same changes as in PR #54 , but targets the v2 branch of laravel-sendinblue (to supports laravel as far back as 5.5).

I'm not aware of any differences in the v2 branch that would require changes, and have been working with this change in a Laravel 6 project. Very happy to make changes if required!