### PR TITLE
fix: illuminate/mail requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "^6.2|^7.0",
-        "illuminate/mail": "^7.0|^8.0",
+        "illuminate/mail": "^7.0|^8.0|^9.0",
         "sendinblue/api-v3-sdk": "^7.4.4"
     },
     "require-dev": {


### PR DESCRIPTION
This PR makes the package installable in Laravel 9 projects.

Related to https://github.com/agence-webup/laravel-sendinblue/issues/55